### PR TITLE
Changing p to div

### DIFF
--- a/src/components/ArticlePreview.tsx
+++ b/src/components/ArticlePreview.tsx
@@ -81,7 +81,7 @@ const ArticlePreview: React.SFC<ArticlePreviewProps> = (props) => {
       </figure>
       <section>
         <h2>{title}</h2>
-        <p
+        <div
           dangerouslySetInnerHTML={{
             __html: descriptionHtml,
           }}


### PR DESCRIPTION
Trying to fix a bug with the description in the post preview.
I recalled reading about a weird react bug with the *p* tag and __dangerouslySetInnerHtml so I changed it to a div and it seems to work.